### PR TITLE
Add missing step in "Summary of steps for Visual Studio Code"

### DIFF
--- a/docs/code-editors/code.md
+++ b/docs/code-editors/code.md
@@ -262,11 +262,12 @@ Unix 11.2.3
 
 Follow these steps to create a solution and projects using Visual Studio Code:
 1.	Create a folder for the solution, for example, `Chapter01`.
-2.	Create a solution file in the folder: `dotnet new sln`.
-3.	Create a folder and project: `dotnet new console -o HelloCS`.
-4.	Add the folder to the solution: `dotnet sln add HelloCS`.
-5.	Repeat steps 4 and 5 to create and add any other projects.
-6.	Open the folder containing the solution using Visual Studio Code: `code .`
+2.	Change to the folder: `cd Chapter01`.
+3.	Create a solution file in the folder: `dotnet new sln`.
+4.	Create a folder and project: `dotnet new console -o HelloCS`.
+5.	Add the folder to the solution: `dotnet sln add HelloCS`.
+6.	Repeat steps 4 and 5 to create and add any other projects.
+7.	Open the folder containing the solution using Visual Studio Code: `code .`
 
 **Console Apps** (`dotnet new console`) are just one type of project template. In this book you will also create **Class Libraries** (`dotnet new classlib`), empty websites (`dotnet new web`), MVC websites (`dotnet new mvc`), Web API services (`dotnet new webapi`), Blazor websites (`dotnet new blazor`), and so on.
 


### PR DESCRIPTION
This is a better solution to the typo in step "Repeat steps 4 and 5 ...".