### PR TITLE
fix: corrected typo in ch10-transactions.md

### DIFF
--- a/docs/ch10-transactions.md
+++ b/docs/ch10-transactions.md
@@ -42,7 +42,7 @@ using Microsoft.EntityFrameworkCore.Storage; // To use IDbContextTransaction.
 
 2.	In the `DeleteProducts` method, after the instantiation of the `db` variable, add statements to start an explicit transaction and output its isolation level. At the bottom of the method, commit the transaction, and close the brace, as shown in the following code:
 ```cs
-static int DeleteProducts(string productNameStartsWith)
+private static int DeleteProducts(string productNameStartsWith)
 {
   using (NorthwindDb db = new())
   {


### PR DESCRIPTION
- Added missing "Db" in the database name.  
- Added access modifier for consistency with the method shown in this section:  
https://github.com/markjprice/cs13net9/blob/main/docs/ch10-modifying.md#deleting-entities
